### PR TITLE
Reduced Schedule

### DIFF
--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-apache-tomcat.yml
+++ b/.github/workflows/update-apache-tomcat.yml
@@ -1,7 +1,7 @@
 name: Update apache-tomcat
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-azure-application-insights.yml
+++ b/.github/workflows/update-azure-application-insights.yml
@@ -1,7 +1,7 @@
 name: Update azure-application-insights
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-bellsoft-liberica.yml
+++ b/.github/workflows/update-bellsoft-liberica.yml
@@ -1,7 +1,7 @@
 name: Update bellsoft-liberica
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-debug.yml
+++ b/.github/workflows/update-debug.yml
@@ -1,7 +1,7 @@
 name: Update debug
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-dist-zip.yml
+++ b/.github/workflows/update-dist-zip.yml
@@ -1,7 +1,7 @@
 name: Update dist-zip
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-draft-release.yml
+++ b/.github/workflows/update-draft-release.yml
@@ -13,7 +13,8 @@ jobs:
               uses: release-drafter/release-drafter@v5
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-encrypt-at-rest.yml
+++ b/.github/workflows/update-encrypt-at-rest.yml
@@ -1,7 +1,7 @@
 name: Update encrypt-at-rest
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-environment-variables.yml
+++ b/.github/workflows/update-environment-variables.yml
@@ -1,7 +1,7 @@
 name: Update environment-variables
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-executable-jar.yml
+++ b/.github/workflows/update-executable-jar.yml
@@ -1,7 +1,7 @@
 name: Update executable-jar
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-google-stackdriver.yml
+++ b/.github/workflows/update-google-stackdriver.yml
@@ -1,7 +1,7 @@
 name: Update google-stackdriver
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -1,7 +1,7 @@
 name: Update gradle
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-image-labels.yml
+++ b/.github/workflows/update-image-labels.yml
@@ -1,7 +1,7 @@
 name: Update image-labels
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-jmx.yml
+++ b/.github/workflows/update-jmx.yml
@@ -1,7 +1,7 @@
 name: Update jmx
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-leiningen.yml
+++ b/.github/workflows/update-leiningen.yml
@@ -1,7 +1,7 @@
 name: Update leiningen
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-maven.yml
+++ b/.github/workflows/update-maven.yml
@@ -1,7 +1,7 @@
 name: Update maven
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-procfile.yml
+++ b/.github/workflows/update-procfile.yml
@@ -1,7 +1,7 @@
 name: Update procfile
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-sbt.yml
+++ b/.github/workflows/update-sbt.yml
@@ -1,7 +1,7 @@
 name: Update sbt
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/update-spring-boot.yml
+++ b/.github/workflows/update-spring-boot.yml
@@ -1,7 +1,7 @@
 name: Update spring-boot
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,7 +9,8 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - name: Docker login gcr.io
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Docker login gcr.io
               uses: docker/login-action@v1
               with:
                 password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}


### PR DESCRIPTION
Previously, the regularly scheduled builds exhausted the free tier of GitHub actions in some orgs.  This change reduces the number of hours and number of days that these scheduled events will run.