### PR TITLE
Add Apache Tomee buildpack

### DIFF
--- a/.github/workflows/update-apache-tomee.yml
+++ b/.github/workflows/update-apache-tomee.yml
@@ -1,0 +1,134 @@
+name: Update apache-tomee
+"on":
+    schedule:
+        - cron: 0 4 * * 4-5
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Update Package Dependency
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - name: Docker login gcr.io
+              if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
+              uses: docker/login-action@v1
+              with:
+                password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}
+                registry: gcr.io
+                username: _json_key
+            - uses: actions/setup-go@v2
+              with:
+                go-version: "1.17"
+            - name: Install update-package-dependency
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                GO111MODULE=on go get -u -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-package-dependency
+            - name: Install crane
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing crane ${CRANE_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --show-error \
+                  --silent \
+                  --location \
+                  "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+                | tar -C "${HOME}/bin" -xz crane
+              env:
+                CRANE_VERSION: 0.8.0
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
+            - name: Update Package Dependency
+              id: package
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
+
+                if [[ -e builder.toml ]]; then
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].uri | capture(\".*${DEPENDENCY}:(?<version>.+)\") | .version")
+
+                  update-package-dependency \
+                    --builder-toml builder.toml \
+                    --id "${DEPENDENCY}" \
+                    --version "${NEW_VERSION}"
+
+                  git add builder.toml
+                fi
+
+                if [[ -e package.toml ]]; then
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].uri | capture(\".*${DEPENDENCY}:(?<version>.+)\") | .version")
+
+                  update-package-dependency \
+                    --buildpack-toml buildpack.toml \
+                    --id "${BP_DEPENDENCY:-$DEPENDENCY}" \
+                    --version "${NEW_VERSION}"
+
+                  update-package-dependency \
+                    --package-toml package.toml \
+                    --id "${PKG_DEPENDENCY:-$DEPENDENCY}" \
+                    --version "${NEW_VERSION}"
+
+                  git add buildpack.toml package.toml
+                fi
+
+                git checkout -- .
+
+                if [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $1}')" != "$(echo "$NEW_VERSION" | awk -F '.' '{print $1}')" ]; then
+                  LABEL="semver:major"
+                elif [ "$(echo "$OLD_VERSION" | awk -F '.' '{print $2}')" != "$(echo "$NEW_VERSION" | awk -F '.' '{print $2}')" ]; then
+                  LABEL="semver:minor"
+                else
+                  LABEL="semver:patch"
+                fi
+
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${NEW_VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
+              env:
+                DEPENDENCY: gcr.io/paketo-buildpacks/apache-tomee
+            - uses: peter-evans/create-pull-request@v3
+              with:
+                author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
+                body: Bumps [`gcr.io/paketo-buildpacks/apache-tomee`](https://gcr.io/paketo-buildpacks/apache-tomee) from [`${{ steps.package.outputs.old-version }}`](https://gcr.io/paketo-buildpacks/apache-tomee:${{ steps.package.outputs.old-version }}) to [`${{ steps.package.outputs.new-version }}`](https://gcr.io/paketo-buildpacks/apache-tomee:${{ steps.package.outputs.new-version }}).
+                branch: update/package/apache-tomee
+                commit-message: |-
+                    Bump gcr.io/paketo-buildpacks/apache-tomee from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}
+
+                    Bumps gcr.io/paketo-buildpacks/apache-tomee from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}.
+                delete-branch: true
+                labels: ${{ steps.package.outputs.version-label }}, type:dependency-upgrade
+                signoff: true
+                title: Bump gcr.io/paketo-buildpacks/apache-tomee from ${{ steps.package.outputs.old-version }} to ${{ steps.package.outputs.new-version }}
+                token: ${{ secrets.JAVA_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The Paketo Java Buildpack is a Cloud Native Buildpack with an order definition s
 ## Included Buildpacks
 
 * [`paketo-buildpacks/apache-tomcat`](https://github.com/paketo-buildpacks/apache-tomcat)
+* [`paketo-buildpacks/apache-tomee`](https://github.com/paketo-buildpacks/apache-tomee)
 * [`paketo-buildpacks/azure-application-insights`](https://github.com/paketo-buildpacks/azure-application-insights)
 * [`paketo-buildpacks/bellsoft-liberica`](https://github.com/paketo-buildpacks/bellsoft-liberica)
 * [`paketo-buildpacks/ca-certificates`](https://github.com/paketo-buildpacks/ca-certificates)

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -86,6 +86,11 @@ api = "0.7"
     version = "7.3.1"
 
   [[order.group]]
+    id = "paketo-buildpacks/apache-tomee"
+    optional = true
+    version = "1.0.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/liberty"
     optional = true
     version = "1.0.1"

--- a/package.toml
+++ b/package.toml
@@ -33,6 +33,9 @@
   uri = "docker://gcr.io/paketo-buildpacks/apache-tomcat:7.3.1"
 
 [[dependencies]]
+  uri = "docker://gcr.io/paketo-buildpacks/apache-tomee:1.0.0"
+
+[[dependencies]]
   uri = "docker://gcr.io/paketo-buildpacks/liberty:1.0.1"
 
 [[dependencies]]


### PR DESCRIPTION
## Summary

Adds the Apache Tomee buildpack, which is a Application Server, to the buildpack. It's placed after Apache Tomcat, as Tomcat is still the default application server.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
