### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/java`
 
-The Paketo Java Buildpack is a Cloud Native Buildpack with an order definition suitable for Java applications.
+The Paketo Buildpack for Java is a Cloud Native Buildpack with an order definition suitable for Java applications.
 
 ## Included Buildpacks
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://paketo.io/docs/howto/java"
   id = "paketo-buildpacks/java"
   keywords = ["java", "composite"]
-  name = "Paketo Java Buildpack"
+  name = "Paketo Buildpack for Java"
   version = "{{.version}}"
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Java Buildpack' to 'Paketo Buildpack for Java'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
