### PR TITLE
Update homepage

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,7 +16,7 @@ api = "0.7"
 
 [buildpack]
   description = "A Cloud Native Buildpack with an order definition suitable for Java applications"
-  homepage = "https://paketo.io/docs/howto/java"
+  homepage = "https://github.com/paketo-buildpacks/java"
   id = "paketo-buildpacks/java"
   keywords = ["java", "composite"]
   name = "Paketo Buildpack for Java"


### PR DESCRIPTION
## Summary

This PR changes the `homepage` property back to the GitHub repository. Running a quick [code search](https://github.com/search?q=org%3Apaketo-buildpacks+%22https%3A%2F%2Fpaketo.io%2F%22+language%3ATOML&type=code) on the paketo org shows, that only three buildpacks use this kind of link for the homepage. This PR is opened for two reasons:

- Alignment of the `homepage` property with other buildpacks
- Enable automatic discovery of version changes for [renovate](https://github.com/renovatebot/renovate) (not working for the three repositories)

If we agree on this, I would open similar PRs for https://github.com/paketo-buildpacks/java-native-image and https://github.com/paketo-buildpacks/java-azure.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
