### PR TITLE
fix: update Tomee integration test version from 10.1 to 10.2

### DIFF
--- a/integration/tomee_test.go
+++ b/integration/tomee_test.go
@@ -43,7 +43,7 @@ func testTomee(t *testing.T, context spec.G, it spec.S) {
 			WithEnv(map[string]string{
 				"BP_ARCH":            "amd64",
 				"BP_JAVA_APP_SERVER": "tomee",
-				"BP_TOMEE_VERSION":   "10.1",
+				"BP_TOMEE_VERSION":   "10.2",
 			}).
 			WithBuilder(builder).
 			WithTrustBuilder().


### PR DESCRIPTION
The Tomee buildpack v1.18.0 ships Apache Tomee 10.2.0 (up from 10.1.5 in v1.17.6). The integration test pinned `BP_TOMEE_VERSION=10.1` which no longer matches any shipped version, causing the integration test to fail.